### PR TITLE
Add chatbot with performance summaries

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <a class="navbar-brand" href="{{ url_for('tasks') }}">Task Manager</a>
     <div class="d-flex">
       {% if session.get('username') %}
+      <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}">Chat</a>
       <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
       <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Logout</a>
       {% endif %}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block title %}Chat{% endblock %}
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <div id="chat-log" class="mb-3" style="height:300px; overflow-y:auto;"></div>
+    <form id="chat-form">
+      <div class="input-group">
+        <input type="text" id="message" class="form-control" placeholder="Type a message" required>
+        <button class="btn btn-primary" type="submit">Send</button>
+      </div>
+    </form>
+  </div>
+</div>
+<script>
+const form = document.getElementById('chat-form');
+const log = document.getElementById('chat-log');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const messageInput = document.getElementById('message');
+  const text = messageInput.value;
+  if(!text) return;
+  appendMessage('You', text);
+  messageInput.value = '';
+  const resp = await fetch('{{ url_for('chat') }}', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({message: text})
+  });
+  if(resp.ok){
+    const data = await resp.json();
+    appendMessage('Bot', data.reply);
+  } else {
+    appendMessage('Bot', 'Error retrieving response.');
+  }
+});
+function appendMessage(sender, text){
+  const p = document.createElement('p');
+  p.innerHTML = `<strong>${sender}:</strong> ${text}`;
+  log.appendChild(p);
+  log.scrollTop = log.scrollHeight;
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add rule-based chat endpoint that returns task statistics
- create chat UI and navigation link
- test chat access and summary generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc89f7479c832ca9511557b8926609