### PR TITLE
Add task notes, history, and drag-and-drop reassignment

### DIFF
--- a/static/dragdrop.js
+++ b/static/dragdrop.js
@@ -1,0 +1,31 @@
+// Basic drag-and-drop reassignment for tasks
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.task-item').forEach(item => {
+    item.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('text/plain', JSON.stringify({
+        user: item.dataset.user,
+        index: item.dataset.index
+      }));
+    });
+  });
+
+  document.querySelectorAll('.task-list').forEach(list => {
+    list.addEventListener('dragover', e => e.preventDefault());
+    list.addEventListener('drop', e => {
+      e.preventDefault();
+      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      const targetUser = list.dataset.user;
+      if (!targetUser) return;
+      if (data.user === targetUser) return;
+      fetch('/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          task_index: data.index,
+          user: data.user,
+          reassign: targetUser
+        })
+      }).then(() => window.location.reload());
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,5 +23,6 @@
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='dragdrop.js') }}"></script>
 </body>
 </html>

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Task Detail{% endblock %}
+{% block content %}
+<h2>{{ task['description'] }}</h2>
+<p><strong>Priority:</strong> {{ task['priority'] }}</p>
+<p><strong>Status:</strong> {{ task['status'] }}</p>
+<p><strong>Created:</strong> {{ task.get('created_at', 'N/A') }}</p>
+
+<h4>Status History</h4>
+<ul>
+  {% for h in task.get('history', []) %}
+  <li>{{ h['timestamp'] }} - {{ h.get('action', '') }} {{ h['status'] }}</li>
+  {% endfor %}
+</ul>
+
+<h4>Notes</h4>
+<ul>
+  {% for n in task.get('notes', []) %}
+  <li>{{ n['timestamp'] }} - {{ n.get('author', '') }}: {{ n['text'] }}</li>
+  {% endfor %}
+</ul>
+
+<form method="post" action="{{ url_for('tasks') }}" class="mb-3">
+  <input type="hidden" name="task_index" value="{{ index }}">
+  <input type="hidden" name="user" value="{{ user }}">
+  <textarea name="note" class="form-control mb-2" placeholder="Add note"></textarea>
+  <button type="submit" class="btn btn-primary">Add Note</button>
+</form>
+<a href="{{ url_for('tasks') }}" class="btn btn-secondary">Back</a>
+{% endblock %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -10,12 +10,12 @@
       <div class="col-md-6 mb-4">
         <div class="card h-100">
           <div class="card-header">{{ uname }}'s Tasks</div>
-          <ul class="list-group list-group-flush">
+          <ul class="list-group list-group-flush task-list" data-user="{{ uname }}">
             {% if udata['tasks'] %}
               {% for task in udata['tasks'] %}
-              <li class="list-group-item">
+              <li class="list-group-item task-item" draggable="true" data-user="{{ uname }}" data-index="{{ loop.index0 }}">
                 <form method="post" class="d-flex justify-content-between align-items-center">
-                  <span>{{ task['description'] }}</span>
+                  <span><a href="{{ url_for('task_detail', user=uname, index=loop.index0) }}">{{ task['description'] }}</a></span>
                   <div class="d-flex align-items-center gap-2">
                     <span class="badge {{ task['priority'] | priority_class }}">{{ task['priority'] }}</span>
                     <select name="status" class="form-select form-select-sm" {% if uname != user %}disabled{% endif %}>
@@ -29,6 +29,16 @@
                     <button type="submit" class="btn btn-sm btn-outline-primary">Update</button>
                     {% endif %}
                   </div>
+                </form>
+                <form method="post" class="d-flex align-items-center mt-2">
+                  <input type="hidden" name="task_index" value="{{ loop.index0 }}">
+                  <input type="hidden" name="user" value="{{ uname }}">
+                  <select name="reassign" class="form-select form-select-sm">
+                    {% for uname2 in all_users.keys() if uname2 != uname %}
+                    <option value="{{ uname2 }}">{{ uname2 }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="submit" class="btn btn-sm btn-outline-secondary ms-2">Reassign</button>
                 </form>
 
               </li>
@@ -71,11 +81,11 @@
 {% else %}
   <div class="card mb-4">
     <div class="card-header">Your Tasks</div>
-    <ul class="list-group list-group-flush">
+    <ul class="list-group list-group-flush" data-user="{{ user }}">
       {% for task in tasks %}
       <li class="list-group-item">
         <form method="post" class="d-flex justify-content-between align-items-center">
-          <span>{{ task['description'] }}</span>
+          <span><a href="{{ url_for('task_detail', user=user, index=loop.index0) }}">{{ task['description'] }}</a></span>
           <div class="d-flex align-items-center gap-2">
             <span class="badge {{ task['priority'] | priority_class }}">{{ task['priority'] }}</span>
             <select name="status" class="form-select form-select-sm">


### PR DESCRIPTION
## Summary
- track task creation time, notes, and status history
- allow reassigning tasks between users including drag-and-drop support
- add detailed task view and tests for notes and reassignment

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc9284ecc8832c89a61f1433d2aa40