### PR TITLE
Add animated task performance charts

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,3 +1,18 @@
 body {
     background-color: #f8f9fa;
 }
+
+.card {
+    animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='dragdrop.js') }}"></script>
 </body>
 </html>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -80,6 +80,19 @@
   </div>
 {% else %}
   <div class="card mb-4">
+    <div class="card-header">Performance</div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-md-6">
+          <canvas id="completionChart"></canvas>
+        </div>
+        <div class="col-md-6">
+          <canvas id="trendChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="card mb-4">
     <div class="card-header">Your Tasks</div>
     <ul class="list-group list-group-flush" data-user="{{ user }}">
       {% for task in tasks %}
@@ -126,6 +139,40 @@
       </form>
     </div>
   </div>
+  <script>
+    const stats = {{ stats | tojson }};
+    const trend = {{ trend | tojson }};
+    new Chart(document.getElementById('completionChart'), {
+      type: 'pie',
+      data: {
+        labels: ['Done', 'Pending'],
+        datasets: [{
+          data: [stats.done, stats.pending],
+          backgroundColor: ['#198754', '#dc3545']
+        }]
+      }
+    });
+    new Chart(document.getElementById('trendChart'), {
+      type: 'line',
+      data: {
+        labels: trend.map(t => t.date),
+        datasets: [
+          {
+            label: 'Created',
+            data: trend.map(t => t.created),
+            borderColor: '#0d6efd',
+            fill: false
+          },
+          {
+            label: 'Done',
+            data: trend.map(t => t.done),
+            borderColor: '#198754',
+            fill: false
+          }
+        ]
+      }
+    });
+  </script>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Compute per-user task stats and trend data on the server
- Visualize task completion rate and history with Chart.js
- Animate cards for a more engaging interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc97256868832cb61a723eb9844b01