### PR TITLE
Revamp chat interface and refresh site styling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,9 +1,33 @@
 body {
-    background-color: #f8f9fa;
+    background: linear-gradient(135deg, #f0f4ff, #d9e4ff);
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+}
+
+.navbar {
+    box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.075);
 }
 
 .card {
     animation: fadeIn 0.5s ease-in;
+    box-shadow: 0 .5rem 1rem rgba(0,0,0,0.05);
+}
+
+#chat-log {
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: .25rem;
+    padding: .5rem;
+}
+
+.chat-message {
+    background-color: #e7f1ff;
+    border-radius: .5rem;
+    padding: .5rem .75rem;
+}
+
+#message {
+    min-height: 3rem;
 }
 
 @keyframes fadeIn {

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,17 +2,20 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Task Manager{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('tasks') }}">Task Manager</a>
+    <a class="navbar-brand fw-semibold" href="{{ url_for('tasks') }}">Task Manager</a>
     <div class="d-flex">
       {% if session.get('username') %}
-      <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}">Chat</a>
+      <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}"><i class="bi bi-chat-dots"></i> Chat</a>
       <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
       <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Logout</a>
       {% endif %}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,113 +1,109 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/templates/chat.html b/templates/chat.html
-index 65aafef5243eac52f7280206172c11240540db74..570ecfa5d097718d8a8551964da0af0b9a31f886 100644
---- a/templates/chat.html
-+++ b/templates/chat.html
-@@ -1,64 +1,101 @@
- {% extends 'base.html' %}
- {% block title %}Chat{% endblock %}
- {% block content %}
- <div class="card">
-   <div class="card-body">
-     <div id="chat-log" class="mb-3" style="height:300px; overflow-y:auto;"></div>
-     <form id="chat-form" enctype="multipart/form-data">
-       <div class="input-group mb-2">
+{% extends 'base.html' %}
+{% block title %}Chat{% endblock %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-header bg-primary text-white">Team Chat</div>
+  <div class="card-body d-flex flex-column">
+    <div id="chat-log" class="flex-grow-1 mb-3"></div>
+    <form id="chat-form" enctype="multipart/form-data">
+      <div class="input-group mb-2">
+        <div id="message" class="form-control" contenteditable="true" placeholder="Type a message"></div>
+        <button class="btn btn-outline-secondary" type="button" id="insert-table">Insert Table</button>
+        <button class="btn btn-primary" type="submit">Send</button>
+      </div>
+      <div id="table-controls" class="btn-group mb-2" style="display:none;">
+        <button class="btn btn-outline-secondary" type="button" id="add-row">Add Row</button>
+        <button class="btn btn-outline-secondary" type="button" id="add-col">Add Column</button>
+      </div>
+      <input type="file" id="file" name="file" class="form-control">
+    </form>
+  </div>
+</div>
+<script>
+const form = document.getElementById('chat-form');
+const log = document.getElementById('chat-log');
 
-+        <div id="message" class="form-control" contenteditable="true" placeholder="Type a message"></div>
-+        <button class="btn btn-secondary" type="button" id="insert-table">Insert Table</button>
-         <button class="btn btn-primary" type="submit">Send</button>
-       </div>
-+      <div id="table-controls" class="btn-group mb-2" style="display:none;" role="group">
-+        <button class="btn btn-outline-secondary" type="button" id="add-row">Add Row</button>
-+        <button class="btn btn-outline-secondary" type="button" id="add-col">Add Column</button>
-+      </div>
-       <input type="file" id="file" name="file" class="form-control">
-     </form>
-   </div>
- </div>
- <script>
- const form = document.getElementById('chat-form');
- const log = document.getElementById('chat-log');
- 
- async function loadMessages(){
-   const resp = await fetch('{{ url_for('chat_messages') }}');
-   if(resp.ok){
-     const data = await resp.json();
-     log.innerHTML = '';
-     data.messages.forEach(m => appendMessage(m.sender, m.text, m.attachments));
-   }
- }
- 
- form.addEventListener('submit', async (e) => {
-   e.preventDefault();
-   const messageInput = document.getElementById('message');
-   const fileInput = document.getElementById('file');
+async function loadMessages() {
+  const resp = await fetch('{{ url_for('chat_messages') }}');
+  if (resp.ok) {
+    const data = await resp.json();
+    log.innerHTML = '';
+    data.messages.forEach(m => appendMessage(m.sender, m.text, m.attachments));
+  }
+}
 
-+  const text = messageInput.innerHTML.trim();
-   const formData = new FormData();
-   formData.append('message', text);
-   if(fileInput.files[0]){
-     formData.append('file', fileInput.files[0]);
-   }
-   await fetch('{{ url_for('chat_messages') }}', {
-     method: 'POST',
-     body: formData
-   });
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const messageInput = document.getElementById('message');
+  const fileInput = document.getElementById('file');
 
-+  messageInput.innerHTML = '';
-   fileInput.value = '';
-+  document.getElementById('table-controls').style.display = 'none';
-   loadMessages();
- });
- 
-+document.getElementById('insert-table').addEventListener('click', () => {
-+  const msg = document.getElementById('message');
-+  const table = document.createElement('table');
-+  table.classList.add('table','table-bordered');
-+  table.innerHTML = '<tr><th>Quantity</th><th>Size</th><th>Color</th></tr><tr><td></td><td></td><td></td></tr>';
-+  msg.appendChild(table);
-+  document.getElementById('table-controls').style.display = 'inline-flex';
-+});
-+
-+document.getElementById('add-row').addEventListener('click', () => {
-+  const table = document.querySelector('#message table');
-+  if(table){
-+    const cols = table.rows[0].cells.length;
-+    const row = table.insertRow();
-+    for(let i=0; i<cols; i++){
-+      row.insertCell();
-+    }
-+  }
-+});
-+
-+document.getElementById('add-col').addEventListener('click', () => {
-+  const table = document.querySelector('#message table');
-+  if(table){
-+    const headerCell = document.createElement('th');
-+    table.rows[0].appendChild(headerCell);
-+    for(let i=1; i<table.rows.length; i++){
-+      table.rows[i].insertCell();
-+    }
-+  }
-+});
-+
- function appendMessage(sender, text, attachments){
-   const p = document.createElement('p');
-   let html = `<strong>${sender}:</strong> ${text}`;
-   if(attachments){
-     attachments.forEach(a => {
-       html += `<br><a href="/static/${a}" target="_blank">Attachment</a>`;
-     });
-   }
-   p.innerHTML = html;
-   log.appendChild(p);
-   log.scrollTop = log.scrollHeight;
- }
- 
- loadMessages();
- setInterval(loadMessages, 5000);
- </script>
- {% endblock %}
- 
-EOF
-)
+  const text = messageInput.innerHTML.trim();
+  if (!text && !fileInput.files.length) {
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('message', text);
+  if (fileInput.files[0]) {
+    formData.append('file', fileInput.files[0]);
+  }
+  await fetch('{{ url_for('chat_messages') }}', {
+    method: 'POST',
+    body: formData
+  });
+
+  messageInput.innerHTML = '';
+  fileInput.value = '';
+  document.getElementById('table-controls').style.display = 'none';
+  loadMessages();
+});
+
+document.getElementById('insert-table').addEventListener('click', () => {
+  const msg = document.getElementById('message');
+  const table = document.createElement('table');
+  table.classList.add('table', 'table-sm', 'table-bordered', 'mb-2');
+  table.innerHTML = '<tr><th>Quantity</th><th>Size</th><th>Color</th></tr><tr><td></td><td></td><td></td></tr>';
+  msg.appendChild(table);
+  document.getElementById('table-controls').style.display = 'inline-flex';
+});
+
+document.getElementById('add-row').addEventListener('click', () => {
+  const table = document.querySelector('#message table');
+  if (table) {
+    const cols = table.rows[0].cells.length;
+    const row = table.insertRow();
+    for (let i = 0; i < cols; i++) {
+      row.insertCell();
+    }
+  }
+});
+
+document.getElementById('add-col').addEventListener('click', () => {
+  const table = document.querySelector('#message table');
+  if (table) {
+    const headerCell = document.createElement('th');
+    table.rows[0].appendChild(headerCell);
+    for (let i = 1; i < table.rows.length; i++) {
+      table.rows[i].insertCell();
+    }
+  }
+});
+
+function appendMessage(sender, text, attachments) {
+  const div = document.createElement('div');
+  div.classList.add('chat-message', 'mb-2');
+  let html = '<span class="fw-bold">' + sender + ':</span> ' + text;
+  if (attachments) {
+    attachments.forEach(a => {
+      html += '<br><a href="/static/' + a + '" target="_blank">Attachment</a>';
+    });
+  }
+  div.innerHTML = html;
+  log.appendChild(div);
+  log.scrollTop = log.scrollHeight;
+}
+
+loadMessages();
+setInterval(loadMessages, 5000);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Rebuild chat template with editable messages, table tools, and modern layout
- Refresh base layout with Bootstrap icons and new navbar styling
- Enhance global styles with gradient background and chat message bubbles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9935d248832c933564557ca95f6e