### PR TITLE
Add user performance graph page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
     <div class="d-flex">
       {% if session.get('username') %}
       <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}"><i class="bi bi-chat-dots"></i> Chat</a>
+      <a class="btn btn-outline-light me-2" href="{{ url_for('graph') }}"><i class="bi bi-bar-chart"></i> Graph</a>
       <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
       <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Logout</a>
       {% endif %}

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block title %}Graph{% endblock %}
+{% block content %}
+<h1 class="mb-4">Graph</h1>
+<div class="row">
+  {% for uname, data in stats.items() %}
+  <div class="col-md-6 mb-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <div class="d-flex align-items-center mb-3">
+          <img src="https://via.placeholder.com/64" alt="avatar" class="rounded-circle me-3">
+          <h5 class="mb-0">{{ uname }}</h5>
+        </div>
+        <div class="progress mb-3">
+          <div class="progress-bar" role="progressbar" style="width: {{ data.performance.completion_rate }}%" aria-valuenow="{{ data.performance.completion_rate }}" aria-valuemin="0" aria-valuemax="100">{{ data.performance.completion_rate | round(1) }}%</div>
+        </div>
+        <canvas id="chart-{{ uname }}"></canvas>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+<script>
+const stats = {{ stats | tojson }};
+for (const [user, info] of Object.entries(stats)) {
+  new Chart(document.getElementById('chart-' + user), {
+    type: 'bar',
+    data: {
+      labels: info.week.labels,
+      datasets: [{
+        label: 'Tasks Done',
+        data: info.week.data,
+        backgroundColor: '#0d6efd'
+      }]
+    },
+    options: {scales: {y: {beginAtZero: true}}}
+  });
+}
+</script>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,3 +150,13 @@ def test_chat_visibility_and_attachments(client):
     msgs = resp.get_json()['messages']
     assert all(m['text'] != '@owner secret' for m in msgs)
 
+
+def test_graph_page_requires_login_and_displays_users(client):
+    resp = client.get('/graph')
+    assert resp.status_code == 302
+
+    client.post('/login', data={'username': 'owner', 'password': 'secret'}, follow_redirects=True)
+    resp = client.get('/graph')
+    assert b'Graph' in resp.data
+    assert b'owner' in resp.data
+


### PR DESCRIPTION
## Summary
- Add a new graph page that displays each user's avatar, task completion progress bar, and 1-week task completion chart.
- Include a navigation link to the graph page and supporting backend route with weekly completion calculations.
- Test that the graph page requires authentication and renders user data.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd00ff7a10832cba16a75da7b6b39a