### PR TITLE
Add user performance graph page and task due dates

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -4,28 +4,31 @@
     "role": "Owner",
     "branches": ["Mzone", "UNIPRO"],
     "tasks": [
-      {"description": "Buy milk", "priority": "High", "status": "Incomplete"},
-      {"description": "Read book", "priority": "Low", "status": "Incomplete"}
-
-    ]
+      {"description": "Buy milk", "priority": "High", "status": "Incomplete", "due_date": "2099-12-31"},
+      {"description": "Read book", "priority": "Low", "status": "Incomplete", "due_date": "2099-12-31"}
+    ],
+    "past_tasks": []
   },
   "sadegh": {
     "password": "password",
     "role": "Worker",
     "branches": ["Mzone", "UNIPRO"],
-    "tasks": []
+    "tasks": [],
+    "past_tasks": []
   },
   "X": {
     "password": "password",
     "role": "Leader",
     "branches": ["UNIPRO"],
-    "tasks": []
+    "tasks": [],
+    "past_tasks": []
   },
   "pedram": {
     "password": "password",
     "role": "IT",
     "branches": ["Babol"],
-    "tasks": []
+    "tasks": [],
+    "past_tasks": []
   }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
     <div class="d-flex">
       {% if session.get('username') %}
       <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}"><i class="bi bi-chat-dots"></i> Chat</a>
+      <a class="btn btn-outline-light me-2" href="{{ url_for('graph') }}"><i class="bi bi-bar-chart"></i> Graph</a>
       <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
       <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Logout</a>
       {% endif %}

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block title %}Graph{% endblock %}
+{% block content %}
+<h1 class="mb-4">Graph</h1>
+<div class="row">
+  {% for uname, data in stats.items() %}
+  <div class="col-md-6 mb-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <div class="d-flex align-items-center mb-3">
+          <img src="https://via.placeholder.com/64" alt="avatar" class="rounded-circle me-3">
+          <h5 class="mb-0">{{ uname }}</h5>
+        </div>
+        <div class="progress mb-3">
+          <div class="progress-bar" role="progressbar" style="width: {{ data.performance.completion_rate }}%" aria-valuenow="{{ data.performance.completion_rate }}" aria-valuemin="0" aria-valuemax="100">{{ data.performance.completion_rate | round(1) }}%</div>
+        </div>
+        <canvas id="chart-{{ uname }}"></canvas>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+<script>
+const stats = {{ stats | tojson }};
+for (const [user, info] of Object.entries(stats)) {
+  new Chart(document.getElementById('chart-' + user), {
+    type: 'bar',
+    data: {
+      labels: info.week.labels,
+      datasets: [{
+        label: 'Tasks Done',
+        data: info.week.data,
+        backgroundColor: '#0d6efd'
+      }]
+    },
+    options: {scales: {y: {beginAtZero: true}}}
+  });
+}
+</script>
+{% endblock %}

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -4,6 +4,7 @@
 <h2>{{ task['description'] }}</h2>
 <p><strong>Priority:</strong> {{ task['priority'] }}</p>
 <p><strong>Status:</strong> {{ task['status'] }}</p>
+<p><strong>Due Date:</strong> {{ task.get('due_date', 'N/A') }}</p>
 <p><strong>Created:</strong> {{ task.get('created_at', 'N/A') }}</p>
 
 <h4>Status History</h4>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -13,9 +13,9 @@
           <ul class="list-group list-group-flush task-list" data-user="{{ uname }}">
             {% if udata['tasks'] %}
               {% for task in udata['tasks'] %}
-              <li class="list-group-item task-item" draggable="true" data-user="{{ uname }}" data-index="{{ loop.index0 }}">
+              <li class="list-group-item task-item {{ task | overdue_class }}" draggable="true" data-user="{{ uname }}" data-index="{{ loop.index0 }}">
                 <form method="post" class="d-flex justify-content-between align-items-center">
-                  <span><a href="{{ url_for('task_detail', user=uname, index=loop.index0) }}">{{ task['description'] }}</a></span>
+                  <span><a href="{{ url_for('task_detail', user=uname, index=loop.index0) }}">{{ task['description'] }}</a> <small class="text-muted ms-2">Due {{ task.get('due_date', 'N/A') }}</small></span>
                   <div class="d-flex align-items-center gap-2">
                     <span class="badge {{ task['priority'] | priority_class }}">{{ task['priority'] }}</span>
                     <select name="status" class="form-select form-select-sm" {% if uname != user %}disabled{% endif %}>
@@ -55,7 +55,7 @@
     <div class="card-header">Add Task</div>
     <div class="card-body">
       <form method="post" class="row gy-2 gx-3 align-items-center">
-        <div class="col-sm-4">
+        <div class="col-sm-3">
           <input type="text" name="task" class="form-control" placeholder="New task" required>
         </div>
         <div class="col-sm-2">
@@ -72,7 +72,10 @@
             {% endfor %}
           </select>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-2">
+          <input type="date" name="due_date" class="form-control">
+        </div>
+        <div class="col-sm-2">
           <button type="submit" class="btn btn-success w-100">Add</button>
         </div>
       </form>
@@ -96,9 +99,9 @@
     <div class="card-header">Your Tasks</div>
     <ul class="list-group list-group-flush" data-user="{{ user }}">
       {% for task in tasks %}
-      <li class="list-group-item">
+      <li class="list-group-item {{ task | overdue_class }}">
         <form method="post" class="d-flex justify-content-between align-items-center">
-          <span><a href="{{ url_for('task_detail', user=user, index=loop.index0) }}">{{ task['description'] }}</a></span>
+          <span><a href="{{ url_for('task_detail', user=user, index=loop.index0) }}">{{ task['description'] }}</a> <small class="text-muted ms-2">Due {{ task.get('due_date', 'N/A') }}</small></span>
           <div class="d-flex align-items-center gap-2">
             <span class="badge {{ task['priority'] | priority_class }}">{{ task['priority'] }}</span>
             <select name="status" class="form-select form-select-sm">
@@ -119,14 +122,29 @@
       {% endif %}
     </ul>
   </div>
+  <div class="card mb-4">
+    <div class="card-header">Past Tasks</div>
+    <ul class="list-group list-group-flush">
+      {% for task in past_tasks %}
+      <li class="list-group-item">
+        <span>{{ task['description'] }}</span>
+        <span class="badge {{ task['priority'] | priority_class }}">{{ task['priority'] }}</span>
+        <small class="text-muted ms-2">Due {{ task.get('due_date', 'N/A') }}</small>
+      </li>
+      {% endfor %}
+      {% if not past_tasks %}
+      <li class="list-group-item text-muted">No past tasks</li>
+      {% endif %}
+    </ul>
+  </div>
   <div class="card">
     <div class="card-header">Add Task</div>
     <div class="card-body">
       <form method="post" class="row gy-2 gx-3 align-items-center">
-        <div class="col-sm-6">
+        <div class="col-sm-5">
           <input type="text" name="task" class="form-control" placeholder="New task" required>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-2">
           <select name="priority" class="form-select">
             <option value="High">High</option>
             <option value="Mid" selected>Mid</option>
@@ -134,6 +152,9 @@
           </select>
         </div>
         <div class="col-sm-3">
+          <input type="date" name="due_date" class="form-control">
+        </div>
+        <div class="col-sm-2">
           <button type="submit" class="btn btn-success w-100">Add</button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- Add a new graph page that displays each user's avatar, task completion progress bar, and 1-week task completion chart.
- Track due dates on tasks, highlight overdue items in red, and archive completed tasks in a past tasks section.
- Show due dates on task detail pages and include tests for past task archiving and overdue highlighting.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd00ff7a10832cba16a75da7b6b39a