### PR TITLE
style: apply classic theme

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,39 +1,50 @@
 body {
-    background: linear-gradient(135deg, #f0f4ff, #d9e4ff);
-    font-family: 'Inter', sans-serif;
+    background: repeating-linear-gradient(
+        45deg,
+        #f5f0e6,
+        #f5f0e6 10px,
+        #ede0d4 10px,
+        #ede0d4 20px
+    );
+    font-family: 'Georgia', serif;
     min-height: 100vh;
+    color: #2c1810;
 }
 
-.navbar {
-    box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.075);
+.classic-nav {
+    background: linear-gradient(90deg, #8b4513, #a0522d);
+    box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.2);
 }
 
 .card {
-    animation: fadeIn 0.5s ease-in;
-    box-shadow: 0 .5rem 1rem rgba(0,0,0,0.05);
+    animation: scrollFade 0.6s ease-in;
+    box-shadow: none;
+    border: 1px solid #deb887;
+    background-color: rgba(255, 255, 255, 0.8);
 }
 
 #chat-log {
-    background-color: #fff;
-    border: 1px solid #dee2e6;
+    background-color: #fffaf0;
+    border: 1px solid #deb887;
     border-radius: .25rem;
     padding: .5rem;
 }
 
 .chat-message {
-    background-color: #e7f1ff;
+    background-color: #fffaf0;
     border-radius: .5rem;
     padding: .5rem .75rem;
+    border: 1px solid #edd5a6;
 }
 
 #message {
     min-height: 3rem;
 }
 
-@keyframes fadeIn {
+@keyframes scrollFade {
     from {
         opacity: 0;
-        transform: translateY(10px);
+        transform: translateY(20px);
     }
     to {
         opacity: 1;

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,11 +6,11 @@
     <title>{% block title %}Task Manager{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+<nav class="navbar navbar-expand-lg navbar-dark classic-nav mb-4">
   <div class="container-fluid">
     <a class="navbar-brand fw-semibold" href="{{ url_for('tasks') }}">Task Manager</a>
     <div class="d-flex">


### PR DESCRIPTION
## Summary
- Replace Inter font and blue theme with a classic Cinzel + Georgia look
- Introduce parchment-like background and brown gradient navbar
- Add subtle scroll fade animation for cards and soften chat styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd081252c4832c9b15d6b938d97c65