### PR TITLE
Fix indentation for manifest route causing Flask startup error

### DIFF
--- a/app.py
+++ b/app.py
@@ -345,7 +345,9 @@ def chat_messages():
         if not m['recipients'] or username in m['recipients']
     ]
     return jsonify({'messages': visible})
-    @app.route('/manifest.json')
+
+
+@app.route('/manifest.json')
 def manifest():
     response = send_from_directory('static', 'manifest.json')
     response.headers['Content-Type'] = 'application/manifest+json'


### PR DESCRIPTION
## Summary
- Fix indentation so manifest and service-worker routes are defined at module level

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd18a684e8832c83ebf07eb7c32aa7