### PR TITLE
Add dashboard with calendar sync and progress tracking

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
     <div class="d-flex">
       {% if session.get('username') %}
       <a class="btn btn-outline-light me-2" href="{{ url_for('chat') }}"><i class="bi bi-chat-dots"></i> Chat</a>
+      <a class="btn btn-outline-light me-2" href="{{ url_for('dashboard') }}"><i class="bi bi-speedometer2"></i> Dashboard</a>
       <a class="btn btn-outline-light me-2" href="{{ url_for('graph') }}"><i class="bi bi-bar-chart"></i> Graph</a>
       <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
       <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Logout</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h2>Dashboard</h2>
+
+<h3>Top 3 Tasks</h3>
+<ul class="list-group mb-4">
+  {% for t in top_tasks %}
+  <li class="list-group-item {{ t | overdue_class }}">
+    {{ t.description }} - {{ t.priority }}{% if t.due_date %} (Due {{ t.due_date }}){% endif %}
+  </li>
+  {% else %}
+  <li class="list-group-item">No tasks</li>
+  {% endfor %}
+</ul>
+
+<h3>Today's Progress</h3>
+<p>{{ progress.done }} of {{ progress.total }} updates completed today</p>
+
+<h3>Upcoming Tasks</h3>
+<ul class="list-group mb-4">
+  {% for t in due_tasks %}
+  <li class="list-group-item">
+    {{ t.description }} - due {{ t.due_date }}
+  </li>
+  {% else %}
+  <li class="list-group-item">No due tasks</li>
+  {% endfor %}
+</ul>
+
+<a class="btn btn-primary" href="{{ url_for('calendar_ics') }}">Sync Calendar (ICS)</a>
+
+<h3 class="mt-4">Your Location</h3>
+<div id="location">Fetching location...</div>
+<script>
+if (navigator.geolocation) {
+  navigator.geolocation.getCurrentPosition(function(pos) {
+    var lat = pos.coords.latitude.toFixed(5);
+    var lon = pos.coords.longitude.toFixed(5);
+    document.getElementById('location').innerText = 'Latitude: ' + lat + ', Longitude: ' + lon;
+  }, function() {
+    document.getElementById('location').innerText = 'Unable to retrieve location';
+  });
+} else {
+  document.getElementById('location').innerText = 'Geolocation not supported';
+}
+</script>
+
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -174,3 +174,19 @@ def test_graph_page_requires_login_and_displays_users(client):
     assert b'Graph' in resp.data
     assert b'owner' in resp.data
 
+
+def test_dashboard_and_calendar(client):
+    client.post('/login', data={'username': 'worker', 'password': 'secret'}, follow_redirects=True)
+    client.post('/tasks', data={'task': 'Task1', 'priority': 'High', 'due_date': '2030-01-01'}, follow_redirects=True)
+    client.post('/tasks', data={'task': 'Task2', 'priority': 'Mid', 'due_date': '2030-01-02'}, follow_redirects=True)
+
+    resp = client.get('/dashboard')
+    assert resp.status_code == 200
+    assert b'Top 3 Tasks' in resp.data
+    assert b'Task1' in resp.data
+
+    resp = client.get('/calendar.ics')
+    assert resp.status_code == 200
+    assert b'BEGIN:VCALENDAR' in resp.data
+    assert b'Task1' in resp.data
+


### PR DESCRIPTION
## Summary
- introduce dashboard showing top tasks, today's progress, and upcoming due dates
- export task due dates as downloadable ICS for calendar sync
- add navigation link and geolocation-based location display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd2d7fb524832c8f10ed0d44a7222f